### PR TITLE
test: add chat settings e2e

### DIFF
--- a/tests/e2e/settings/chatSettings.spec.ts
+++ b/tests/e2e/settings/chatSettings.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+// Use the working authentication
+// Storage state path from existing tests
+
+test.use({ storageState: "tests/e2e/.auth/user.json" });
+
+test.describe("Chat Settings", () => {
+  test("should render code snippet and HMAC secret and persist toggle", async ({ page }) => {
+    // Navigate to chat settings
+    await page.goto("/settings/in-app-chat");
+    await page.waitForLoadState("networkidle");
+
+    // Verify a code block is visible (codeBlock.tsx)
+    await expect(page.locator("pre.code").first()).toBeVisible();
+
+    // Expand "Authenticate your users" to reveal HMAC secret input
+    await page.getByRole("button", { name: "Authenticate your users" }).click();
+    await expect(page.getByLabel("HMAC Secret")).toBeVisible();
+
+    // Toggle "Chat Icon Visibility" switch and confirm persistence after reload
+    const switchLocator = page.getByRole("switch", { name: "Chat Icon Visibility Switch" });
+    await switchLocator.scrollIntoViewIfNeeded();
+    const initialState = await switchLocator.getAttribute("data-state");
+
+    await switchLocator.click();
+    // allow debounce + network save
+    await page.waitForTimeout(1500);
+    await page.waitForLoadState("networkidle");
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+
+    const reloadedSwitch = page.getByRole("switch", { name: "Chat Icon Visibility Switch" });
+    const newState = await reloadedSwitch.getAttribute("data-state");
+    expect(newState).not.toBe(initialState);
+
+    // Revert to original state
+    await reloadedSwitch.click();
+    await page.waitForTimeout(1500);
+  });
+});


### PR DESCRIPTION
## Summary
- add e2e test for chat settings verifying code snippet, hmac secret and toggle persistence

## Testing
- `pnpm test:e2e tests/e2e/settings/chatSettings.spec.ts` *(fails: Supabase test containers are not running)*
- `pnpm test:e2e:setup` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_688c034c17a883278aad5c1b97506fba